### PR TITLE
Chapterlist DecodingError fix

### DIFF
--- a/MangaDexLib.xcodeproj/project.pbxproj
+++ b/MangaDexLib.xcodeproj/project.pbxproj
@@ -35,7 +35,6 @@
 		3322BD73245D99130086FA81 /* MDPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3322BD52245D99120086FA81 /* MDPath.swift */; };
 		3322BD74245D99130086FA81 /* MDPath+Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3322BD53245D99120086FA81 /* MDPath+Constants.swift */; };
 		3322BD90245D99900086FA81 /* MDLibRequestHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3322BD87245D99900086FA81 /* MDLibRequestHandlerTests.swift */; };
-		3322BD93245D99900086FA81 /* Secret.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 3322BD8A245D99900086FA81 /* Secret.bundle */; };
 		3322BD94245D99900086FA81 /* MDLibApiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3322BD8B245D99900086FA81 /* MDLibApiTests.swift */; };
 		33248542266B710600561361 /* MDPath+Cover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33248541266B710600561361 /* MDPath+Cover.swift */; };
 		33248543266B710600561361 /* MDPath+Cover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33248541266B710600561361 /* MDPath+Cover.swift */; };
@@ -150,6 +149,7 @@
 		33A6D5A526485A68007AB5B4 /* MDReadingStatuses.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33A6D5A326485A68007AB5B4 /* MDReadingStatuses.swift */; };
 		33FB8F9526726F7500D48312 /* MDUserFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33FB8F9426726F7500D48312 /* MDUserFilter.swift */; };
 		33FB8F9626726F7500D48312 /* MDUserFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33FB8F9426726F7500D48312 /* MDUserFilter.swift */; };
+		FEE09C0A26BEE8E4005EF15D /* Secret.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FEE09C0926BEE8E4005EF15D /* Secret.bundle */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -186,7 +186,6 @@
 		3322BD84245D99900086FA81 /* LinuxMain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinuxMain.swift; sourceTree = "<group>"; };
 		3322BD87245D99900086FA81 /* MDLibRequestHandlerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MDLibRequestHandlerTests.swift; sourceTree = "<group>"; };
 		3322BD88245D99900086FA81 /* XCTestManifests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestManifests.swift; sourceTree = "<group>"; };
-		3322BD8A245D99900086FA81 /* Secret.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Secret.bundle; sourceTree = "<group>"; };
 		3322BD8B245D99900086FA81 /* MDLibApiTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MDLibApiTests.swift; sourceTree = "<group>"; };
 		3322BDA8245DA4AC0086FA81 /* MangaDexLib.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MangaDexLib.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		33248541266B710600561361 /* MDPath+Cover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MDPath+Cover.swift"; sourceTree = "<group>"; };
@@ -247,6 +246,7 @@
 		33A6D59D26485868007AB5B4 /* MDReadMarkers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDReadMarkers.swift; sourceTree = "<group>"; };
 		33A6D5A326485A68007AB5B4 /* MDReadingStatuses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDReadingStatuses.swift; sourceTree = "<group>"; };
 		33FB8F9426726F7500D48312 /* MDUserFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDUserFilter.swift; sourceTree = "<group>"; };
+		FEE09C0926BEE8E4005EF15D /* Secret.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Secret.bundle; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -378,7 +378,7 @@
 				33901B36264D338600A12755 /* MDLibApiTests+Infra.swift */,
 				3322BD87245D99900086FA81 /* MDLibRequestHandlerTests.swift */,
 				3322BD88245D99900086FA81 /* XCTestManifests.swift */,
-				3322BD8A245D99900086FA81 /* Secret.bundle */,
+				FEE09C0926BEE8E4005EF15D /* Secret.bundle */,
 			);
 			path = MangaDexLibTests;
 			sourceTree = "<group>";
@@ -591,7 +591,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3322BD93245D99900086FA81 /* Secret.bundle in Resources */,
+				FEE09C0A26BEE8E4005EF15D /* Secret.bundle in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/API/MDConstants.swift
+++ b/Sources/API/MDConstants.swift
@@ -113,6 +113,8 @@ public enum MDObjectType: String, Codable {
 
     /// The resource is a user
     case user = "user"
+	case leader = "leader"
+	case member = "member"
 
     /// The resource is a user's custom list
     case customList = "custom_list"

--- a/Sources/Objects/MDGroup.swift
+++ b/Sources/Objects/MDGroup.swift
@@ -85,6 +85,24 @@ extension MDGroup: Decodable {
         case version
     }
 
+	public init(from decoder: Decoder) throws {
+		let container = try decoder.container(keyedBy: CodingKeys.self)
+		name = try container.decode(String.self, forKey: .name)
+		description = try container.decodeIfPresent(String.self, forKey: .description)
+		leader = try? container.decodeIfPresent(MDObject<MDUser>.self, forKey: .leader)
+		members = try container.decodeIfPresent([MDObject<MDUser>].self, forKey: .members) ?? []
+		locked = try container.decodeIfPresent(Bool.self, forKey: .locked)
+		website = try container.decodeIfPresent(URL.self, forKey: .website)
+		ircServer = try container.decodeIfPresent(String.self, forKey: .ircServer)
+		ircChannel = try container.decodeIfPresent(String.self, forKey: .ircChannel)
+		discord = try container.decodeIfPresent(String.self, forKey: .discord)
+		contactEmail = try container.decodeIfPresent(String.self, forKey: .contactEmail)
+		createdDate = try container.decode(Date.self, forKey: .createdDate)
+		updatedDate = try container.decodeIfPresent(Date.self, forKey: .updatedDate)
+		leaderId = try container.decodeIfPresent(String.self, forKey: .leaderId)
+		memberIds = try container.decodeIfPresent([String].self, forKey: .memberIds)
+		version = try container.decode(Int.self, forKey: .version)
+	}
 }
 
 extension MDGroup: Encodable {

--- a/Sources/Objects/MDRelationship.swift
+++ b/Sources/Objects/MDRelationship.swift
@@ -49,7 +49,7 @@ extension MDRelationship: Decodable {
             return try container.decode(MDGroup?.self, forKey: .data)
         case .tag:
             return try container.decode(MDTag?.self, forKey: .data)
-        case .user:
+		case .user, .member, .leader:
             return try container.decode(MDUser?.self, forKey: .data)
         case .customList:
             return try container.decode(MDCustomList?.self, forKey: .data)

--- a/Tests/MangaDexLibTests/MDLibApiTests+Chapter.swift
+++ b/Tests/MangaDexLibTests/MDLibApiTests+Chapter.swift
@@ -24,27 +24,51 @@ extension MDLibApiTests {
         waitForExpectations(timeout: 15, handler: nil)
     }
 
-    func testSearchChapters() throws {
-        throw XCTSkip("Chapter search is currently broken in the official API")
+	func testSearchChapters() throws {
+		throw XCTSkip("Chapter search is currently broken in the official API")
 
-        let filter = MDChapterFilter(title: "Oneshot")
-        filter.createdAtSince = .init(timeIntervalSince1970: 0)
-        filter.limit = 3
-        filter.offset = 7
+		let filter = MDChapterFilter(title: "Oneshot")
+		filter.createdAtSince = .init(timeIntervalSince1970: 0)
+		filter.limit = 3
+		filter.offset = 7
 
-        let expectation = self.expectation(description: "Get a list of chapters")
-        api.getChapterList(filter: filter) { (result, error) in
-            XCTAssertNil(error)
-            XCTAssertNotNil(result)
-            XCTAssert(result!.results.count > 0)
-            XCTAssertNotNil(result?.results.first?.object)
-            XCTAssertNotNil(result?.results.first?.object?.data)
-            XCTAssertEqual(result?.limit, filter.limit)
-            XCTAssertEqual(result?.offset, filter.offset)
-            expectation.fulfill()
-        }
-        waitForExpectations(timeout: 15, handler: nil)
-    }
+		let expectation = self.expectation(description: "Get a list of chapters")
+		api.getChapterList(filter: filter) { (result, error) in
+			XCTAssertNil(error)
+			XCTAssertNotNil(result)
+			XCTAssert(result!.results.count > 0)
+			XCTAssertNotNil(result?.results.first?.object)
+			XCTAssertNotNil(result?.results.first?.object?.data)
+			XCTAssertEqual(result?.limit, filter.limit)
+			XCTAssertEqual(result?.offset, filter.offset)
+			expectation.fulfill()
+		}
+		waitForExpectations(timeout: 15, handler: nil)
+	}
+	
+	func testGetChapterForManga() throws {
+		let mangaId = "0cf91ce5-5033-4fce-8687-b14c6a4d10b6" //Hone Dragon no Mana Musume
+		let filter = MDChapterFilter()
+		filter.limit = 1
+		filter.manga = mangaId
+
+		let expectation = self.expectation(description: "Get a list of chapters for a specific manga with populated scanlationGroup")
+		
+		api.getChapterList(filter: filter, includes: [.scanlationGroup]) { (result, error) in
+			XCTAssertNil(error)
+			XCTAssert(result!.results.count > 0)
+			XCTAssert(result!.results.count > 0)
+			XCTAssertNotNil(result!.results.first?.object)
+			let scanlationGroup = result!.results.first?
+				.relationships?
+				.first(where: { $0.objectType == .scanlationGroup })?
+				.data as? MDGroup
+			
+			XCTAssertNotNil(scanlationGroup)
+			expectation.fulfill()
+		}
+		waitForExpectations(timeout: 15, handler: nil)
+	}
 
     func testViewChapter() throws {
         let chapterId = "946577a4-d469-45ed-8400-62f03ce4942e" // Solo leveling volume 1 chapter 1 (en)

--- a/Tests/MangaDexLibTests/MDLibApiTests+Group.swift
+++ b/Tests/MangaDexLibTests/MDLibApiTests+Group.swift
@@ -46,13 +46,20 @@ extension MDLibApiTests {
     func testViewScanlationGroup() throws {
         let groupId = "b8a6d1fc-1634-47a8-98cf-2ea3f5fef8b3" // MangaDex Scans
         let expectation = self.expectation(description: "Get the scanlation group's information")
-        api.viewGroup(groupId: groupId) { (result, error) in
+		api.viewGroup(groupId: groupId, includes: [.member, .leader]) { (result, error) in
             XCTAssertNil(error)
             XCTAssertNotNil(result)
             XCTAssertNotNil(result?.object?.data)
             XCTAssertEqual(result?.object?.data.name, "MangaDex Scans")
-            XCTAssertEqual(result?.object?.data.leader?.objectId, "17179fd6-77fb-484a-a543-aaea12511c07")
-            XCTAssert(result!.object!.data.members.count > 0)
+			guard let leader = result!.relationships?.first(where: { $0.objectType == .leader }) else {
+				return XCTFail("leader not found")
+			}
+            XCTAssertEqual(leader.objectId, "17179fd6-77fb-484a-a543-aaea12511c07")
+			
+			guard let members = result!.relationships?.filter({ $0.objectType == .member }) else {
+				return XCTFail("members not found")
+			}
+			XCTAssert(members.count > 0)
             expectation.fulfill()
         }
         waitForExpectations(timeout: 15, handler: nil)


### PR DESCRIPTION
Fixed a bug where an DecodingError occured when trying to fetch a specific mangas chapterList, because members are delivered empty from the api in that case.